### PR TITLE
Catch ID not set

### DIFF
--- a/build/scripts/build.php
+++ b/build/scripts/build.php
@@ -44,6 +44,7 @@ class DPDockerReleaseBuild
 			// Iterate over the files in the manifest
 			foreach ($manifest->files->file as $file) {
 				$extension = null;
+				$id = "";
 
 				// Look for an override in the build config
 				foreach ($package->extensions as $ex) {
@@ -55,7 +56,7 @@ class DPDockerReleaseBuild
 				}
 
 				// If none override is found, create an extension from the manifest
-				if ($extension == null && isset($id)) {
+				if ($extension == null) {
 					$extension = (object)['name' => $id];
 				}
 				$extensions[] = $extension;

--- a/build/scripts/build.php
+++ b/build/scripts/build.php
@@ -55,7 +55,7 @@ class DPDockerReleaseBuild
 				}
 
 				// If none override is found, create an extension from the manifest
-				if ($extension == null) {
+				if ($extension == null && isset($id)) {
 					$extension = (object)['name' => $id];
 				}
 				$extensions[] = $extension;

--- a/build/scripts/build.php
+++ b/build/scripts/build.php
@@ -25,7 +25,7 @@ class DPDockerReleaseBuild
 		// Read the build config
 		$config = json_decode(file_get_contents($this->extensionRoot . '/package/build.json'));
 		foreach ($config->packages as $package) {
-			// prepare the temp folder
+			// Prepare the temp folder
 			$tmpFolder = dirname($this->extensionRoot) . '/build';
 			shell_exec('rm -rf ' . $tmpFolder);
 			mkdir($tmpFolder);
@@ -63,7 +63,7 @@ class DPDockerReleaseBuild
 
 			// Loop over the extensions
 			foreach ($extensions as $extension) {
-				// Default hte excludes
+				// Default the excludes
 				$excludes = [];
 				if (!empty($extension->excludes)) {
 					foreach ($extension->excludes as $exclude) {


### PR DESCRIPTION
Actually, that shouldn't happen, but if you make an error in the build file, then the ID may not be set and throws an error. Maybe you like to add that.