### PR TITLE
Check whether the branch name ( what is used as database name) includes points or hyphens (replaced this with an underscore)

### DIFF
--- a/joomla-pr/scripts/exec-joomla-pr-webserver.sh
+++ b/joomla-pr/scripts/exec-joomla-pr-webserver.sh
@@ -53,7 +53,9 @@ if [ -z $dbHost ]; then
   dbHost="mysql"
 fi
 
-/var/www/html/Projects/DPDocker/webserver/scripts/install-joomla.sh $root $dbHost-pr pr_$1 "Joomla PR $1" mailcatcher-pr $3
+dbName="$1" | sed -r 's/[.-]+/_/g'
+
+/var/www/html/Projects/DPDocker/webserver/scripts/install-joomla.sh $root $dbHost-pr prorbranch_$dbName "Joomla PR or Branch $1" mailcatcher-pr $3
 
 echo -e "\e[32mPR $1 is checked out and ready to test on http://localhost:8090/pr/$1/administrator!"
 echo -e "\e[32mYou can log in with admin/admin!"


### PR DESCRIPTION
`./run-joomla-pr-webserver.sh 4.0-dev` is not possible [here](https://github.com/Digital-Peak/DPDocker/tree/master/joomla-pr#execute), because  `4.0-dev` is used as `dbname`. `dbname `in mysql can not include point or hyphen.
