### PR TITLE
Start of Named parameters for tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -11,13 +11,16 @@ If you  have some install tasks which should be executed before every test, then
 ## Execute
 To run the extension tests, execute the following command:
 
-`./run-system-tests.sh --EXTENSION extension [--TEST test]`
+`./run-system-tests.sh --EXTENSION extension [--TEST test] [--JOOMLA_MAJOR_VERSION version]`
 
 Example
 
-`./run-system-tests.sh --EXTENSION Foo --TEST tests/acceptance/views/ArticleViewCest.php:canSeeUploadFormInArticle`
+`./run-system-tests.sh --EXTENSION Foo --TEST tests/acceptance/views/ArticleViewCest.php:canSeeUploadFormInArticle --JOOMLA_MAJOR_VERSION 4`
 
-The test attribute is optional. If it is set then only this test is executed, otherwise the whole extension.
+The `test`, `rebuild` and `joomla_major_version` attributes are optional.  
+- If `test` is set then only this test is executed, otherwise the whole extension.  
+- If `rebuild` is not set then it defaults to false. 
+- If `joomla_major_version` is _not_ set then version `3` is used. You have to set it to `4` if you need Joomla version 4.
 
 ## Internals
 Running the system tests is a rather complex setup. Due some startup issues we need to start every container manually. Five containers are started actually. First the mySQL container. Then the web server which is accessible on the url _localhost:8080/joomla_ and selenium. If all are up, then the actual system tests are executed.

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,11 +11,11 @@ If you  have some install tasks which should be executed before every test, then
 ## Execute
 To run the extension tests, execute the following command:
 
-`./run-system-tests.sh extension [test]`
+`./run-system-tests.sh --EXTENSION extension [--TEST test]`
 
 Example
 
-`./run-system-tests.sh Foo tests/acceptance/views/ArticleViewCest.php:canSeeUploadFormInArticle`
+`./run-system-tests.sh --EXTENSION Foo --TEST tests/acceptance/views/ArticleViewCest.php:canSeeUploadFormInArticle`
 
 The test attribute is optional. If it is set then only this test is executed, otherwise the whole extension.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,7 @@ Example
 
 `./run-system-tests.sh --EXTENSION Foo --TEST tests/acceptance/views/ArticleViewCest.php:canSeeUploadFormInArticle --JOOMLA_MAJOR_VERSION 4`
 
-The `test`, `rebuild` and `joomla_major_version` attributes are optional.  
+The `test`, `rebuild` and `joomla_major_version` attributes are optional:    
 - If `test` is set then only this test is executed, otherwise the whole extension.  
 - If `rebuild` is not set then it defaults to false. 
 - If `joomla_major_version` is _not_ set then version `3` is used. You have to set it to `4` if you need Joomla version 4.
@@ -28,6 +28,8 @@ Running the system tests is a rather complex setup. Due some startup issues we n
 During a test PHPMyAdmin is available under _localhost:8081_ and the mailcatcher on _localhost:8082_.
 
 Every suite needs an install folder which contains some setup tasks during installation of the extension. The order of the other tests is randomly to prevent execution order issues as every tests need to be isolated.
+
+If you like to test an installation, please run run [`./build/run.sh extension [version]`](https://github.com/Digital-Peak/DPDocker/tree/master/build). All in this task created Zip files will be copied before starting the tests to the root of the webserver. So you are able to use them in a test.  
 
 ### Mailcatcher usage
 Mailcatcher has a simple REST interface where you can interact with the mails. To access mailcatcher in codeception use the host mailcatcher-test:1080. The following code snippet is an example how to test if a mail contains a string:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -22,7 +22,7 @@ services:
   web-test:
     image: dpdocker-web
     environment:
-      STARTUP_COMMAND_1: php /var/www/html/Projects/DPDocker/webserver/scripts/setup-joomla-site.php joomla ${EXTENSION} mysql-test ${REBUILD}
+      STARTUP_COMMAND_1: php /var/www/html/Projects/DPDocker/webserver/scripts/setup-joomla-site.php joomla ${EXTENSION} mysql-test ${REBUILD} ${JOOMLA_MAJOR_VERSION}
       # Some defaults
       STARTUP_COMMAND_2: sudo sed -i "s/debug = '1'/debug = 0/g" /var/www/html/joomla/configuration.php
       STARTUP_COMMAND_3: sudo sed -i "s/sef = '1'/sef = 0/g" /var/www/html/joomla/configuration.php

--- a/tests/run-system-tests.sh
+++ b/tests/run-system-tests.sh
@@ -3,6 +3,17 @@
 # @copyright Copyright (C) 2020 Digital Peak GmbH. <https://www.digital-peak.com>
 # @license   http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL
 
+TEST=${TEST:-}
+EXTENSION=${EXTENSION:-}
+
+while [ $# -gt 0 ]; do
+   if [[ $1 == *"--"* ]]; then
+        param="${1/--/}"
+        declare $param="$2"
+   fi
+  shift
+done
+
 if [[ ! $(command -v curl) ]]; then
   echo "Error: curl is not installed, can't run the tests!"
   exit 1
@@ -24,15 +35,15 @@ if [ -z "$2" ]; then
   fi
 
   # We start mysql early to rebuild the database
-  EXTENSION=$1 TEST=$2 REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d mysql-test
+  EXTENSION=$EXTENSION TEST=$TEST REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d mysql-test
   sleep 5
 fi
 
 # Run containers in detached mode so when the system tests command ends, we can stop them afterwards
-EXTENSION=$1 TEST=$2 REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d phpmyadmin-test
-EXTENSION=$1 TEST=$2 REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d mailcatcher-test
-EXTENSION=$1 TEST=$2 REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d web-test
-EXTENSION=$1 TEST=$2 REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d selenium-test
+EXTENSION=$EXTENSION TEST=$TEST REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d phpmyadmin-test
+EXTENSION=$EXTENSION TEST=$TEST REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d mailcatcher-test
+EXTENSION=$EXTENSION TEST=$TEST REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d web-test
+EXTENSION=$EXTENSION TEST=$TEST REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d selenium-test
 
 # Waiting for web server
 while ! curl http://localhost:8080 > /dev/null 2>&1; do
@@ -52,7 +63,7 @@ if [[ $(command -v vinagre) ]]; then
 fi
 
 # Run the tests
-EXTENSION=$1 TEST=$2 REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml run system-tests
+EXTENSION=$EXTENSION TEST=$TEST REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml run system-tests
 
 # Stop the containers
 if [ -z "$2" ]; then

--- a/tests/run-system-tests.sh
+++ b/tests/run-system-tests.sh
@@ -5,6 +5,8 @@
 
 TEST=${TEST:-}
 EXTENSION=${EXTENSION:-}
+REBUILD=${REBUILD:-false}
+JOOMLA_MAJOR_VERSION=${JOOMLA_MAJOR_VERSION:-}
 
 while [ $# -gt 0 ]; do
    if [[ $1 == *"--"* ]]; then
@@ -35,15 +37,15 @@ if [ -z "$2" ]; then
   fi
 
   # We start mysql early to rebuild the database
-  EXTENSION=$EXTENSION TEST=$TEST REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d mysql-test
+  JOOMLA_MAJOR_VERSION=$JOOMLA_MAJOR_VERSION EXTENSION=$EXTENSION TEST=$TEST REBUILD=$REBUILD docker-compose -f $(dirname $0)/docker-compose.yml up -d mysql-test
   sleep 5
 fi
 
 # Run containers in detached mode so when the system tests command ends, we can stop them afterwards
-EXTENSION=$EXTENSION TEST=$TEST REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d phpmyadmin-test
-EXTENSION=$EXTENSION TEST=$TEST REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d mailcatcher-test
-EXTENSION=$EXTENSION TEST=$TEST REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d web-test
-EXTENSION=$EXTENSION TEST=$TEST REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml up -d selenium-test
+JOOMLA_MAJOR_VERSION=$JOOMLA_MAJOR_VERSION EXTENSION=$EXTENSION TEST=$TEST REBUILD=$REBUILD docker-compose -f $(dirname $0)/docker-compose.yml up -d phpmyadmin-test
+JOOMLA_MAJOR_VERSION=$JOOMLA_MAJOR_VERSION EXTENSION=$EXTENSION TEST=$TEST REBUILD=$REBUILD docker-compose -f $(dirname $0)/docker-compose.yml up -d mailcatcher-test
+JOOMLA_MAJOR_VERSION=$JOOMLA_MAJOR_VERSION EXTENSION=$EXTENSION TEST=$TEST REBUILD=$REBUILD docker-compose -f $(dirname $0)/docker-compose.yml up -d web-test
+JOOMLA_MAJOR_VERSION=$JOOMLA_MAJOR_VERSION EXTENSION=$EXTENSION TEST=$TEST REBUILD=$REBUILD docker-compose -f $(dirname $0)/docker-compose.yml up -d selenium-test
 
 # Waiting for web server
 while ! curl http://localhost:8080 > /dev/null 2>&1; do
@@ -63,7 +65,7 @@ if [[ $(command -v vinagre) ]]; then
 fi
 
 # Run the tests
-EXTENSION=$EXTENSION TEST=$TEST REBUILD= docker-compose -f $(dirname $0)/docker-compose.yml run system-tests
+JOOMLA_MAJOR_VERSION=$JOOMLA_MAJOR_VERSION EXTENSION=$EXTENSION TEST=$TEST REBUILD=$REBUILD docker-compose -f $(dirname $0)/docker-compose.yml run system-tests
 
 # Stop the containers
 if [ -z "$2" ]; then

--- a/webserver/scripts/setup-joomla-site.php
+++ b/webserver/scripts/setup-joomla-site.php
@@ -5,11 +5,12 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU/GPL
  */
 
-$hasInternet = true;
-$wwwRoot     = '/var/www/html/' . $argv[1];
-$db          = array_key_exists(3, $argv) ? $argv[3] : 'mysql';
-$force       = array_key_exists(4, $argv) ? (bool)$argv[4] : false;
-$binary      = '/home/docker/vendor/bin/joomla';
+$hasInternet          = true;
+$wwwRoot              = '/var/www/html/' . $argv[1];
+$db                   = array_key_exists(3, $argv) ? $argv[3] : 'mysql';
+$force                = array_key_exists(4, $argv) ? (bool)$argv[4] : false;
+$joomla_major_version = array_key_exists(5, $argv) ? $argv[5] : substr($argv[1], -1);
+$binary               = '/home/docker/vendor/bin/joomla';
 
 if (is_dir($wwwRoot) && !$force) {
 	return;
@@ -31,8 +32,8 @@ if (!is_dir($wwwRoot) || $force) {
 	shell_exec('rm -rf ' . $wwwRoot);
 	shell_exec('cp -r /var/www/html/cache ' . $wwwRoot);
 
-	if (substr($argv[1], -1) == 4 && $hasInternet) {
-		// Checkout latest stable release
+	if ($joomla_major_version == '4' && $hasInternet) {
+			// Checkout latest stable release
 		shell_exec('git --work-tree=' . $wwwRoot . ' --git-dir=' . $wwwRoot . '/.git checkout tags/4.0.0-beta5 2>&1 > /dev/null');
 		echo 'Using version 4.0.0-beta5 on ' . $wwwRoot . PHP_EOL;
 	} else if ($hasInternet) {
@@ -56,6 +57,8 @@ echo shell_exec('/var/www/html/Projects/DPDocker/webserver/scripts/install-jooml
 if (!$argv[2]) {
 	return;
 }
+
+shell_exec('cp -r "/var/www/html/Projects/DPDocker/build/dist/"*.zip ' . $wwwRoot);
 
 $folders = explode(',', $argv[2]);
 if ($argv[2] == 'all') {

--- a/webserver/scripts/setup-joomla-site.php
+++ b/webserver/scripts/setup-joomla-site.php
@@ -33,7 +33,7 @@ if (!is_dir($wwwRoot) || $force) {
 	shell_exec('cp -r /var/www/html/cache ' . $wwwRoot);
 
 	if ($joomla_major_version == '4' && $hasInternet) {
-			// Checkout latest stable release
+		// Checkout latest stable release
 		shell_exec('git --work-tree=' . $wwwRoot . ' --git-dir=' . $wwwRoot . '/.git checkout tags/4.0.0-beta5 2>&1 > /dev/null');
 		echo 'Using version 4.0.0-beta5 on ' . $wwwRoot . PHP_EOL;
 	} else if ($hasInternet) {


### PR DESCRIPTION
I tried it with [this](https://github.com/astridx/AG) test extension.

`./tests/run-system-tests.sh --EXTENSION AG --JOOMLA_MAJOR_VERSION 4`  
tests with Joomla 4 and installs the extension if it was created beforehand via 
`./build/run.sh AG.`

